### PR TITLE
Improve test coverage on API module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,9 @@ jobs:
           command: generate-lockfile
       - name: cargo llvm-cov
         run: cargo llvm-cov --locked --all-features --lcov --output-path lcov.info
+        env:
+          UBISOFT_EMAIL: ${{ secrets.UBISOFT_EMAIL }}
+          UBISOFT_PASSWORD: ${{ secrets.UBISOFT_PASSWORD }}
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:

--- a/siege-api/Cargo.toml
+++ b/siege-api/Cargo.toml
@@ -21,4 +21,5 @@ tracing = "0.1.37"
 uuid = { version = "1.3.0", features = ["serde"] }
 
 [dev-dependencies]
+async_once = "0.2.6"
 serde_json = "1.0.95"

--- a/siege-api/src/auth.rs
+++ b/siege-api/src/auth.rs
@@ -86,7 +86,7 @@ impl PartialEq for ConnectError {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Getters)]
+#[derive(Debug, Clone, Deserialize, Serialize, Getters)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectResponse {
     platform_type: PlatformType,

--- a/siege-api/src/auth.rs
+++ b/siege-api/src/auth.rs
@@ -132,24 +132,37 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore = "Missing credentials in CI"]
-    async fn connect() {
-        let auth = Auth::from_environment();
-
-        let response = auth.connect().await;
-        println!("{:?}", response.unwrap());
-    }
-
-    #[tokio::test]
     async fn connect_with_incorrect_credentials() {
-        let auth = Auth {
-            username: "abc".to_string(),
-            password: "123".to_string(),
-        };
+        let auth = Auth::new("abc".to_string(), "123".to_string());
 
         assert_eq!(
             auth.connect().await.unwrap_err(),
             ConnectError::InvalidPassword
+        );
+    }
+
+    #[test]
+    fn auth_debug() {
+        let auth = Auth::new("abc".to_string(), "123".to_string());
+
+        assert_eq!(
+            format!("{auth:?}"),
+            "Auth { username: \"abc\", password: \"123\" }"
+        );
+    }
+
+    #[test]
+    fn connect_error_eq() {
+        assert_eq!(ConnectError::InvalidPassword, ConnectError::InvalidPassword);
+        assert_eq!(
+            ConnectError::UnexpectedResponse,
+            ConnectError::UnexpectedResponse
+        );
+
+        // Not equal
+        assert_ne!(
+            ConnectError::InvalidPassword,
+            ConnectError::UnexpectedResponse
         );
     }
 }

--- a/siege-api/src/constants.rs
+++ b/siege-api/src/constants.rs
@@ -3,4 +3,5 @@
 pub const UBI_APP_ID: &str = "e3d5ea9e-50bd-43b7-88bf-39794f4e3d40";
 pub const UBI_USER_AGENT: &str = "UbiServices_SDK_2020.Release.58_PC64_ansi_static";
 
+#[allow(dead_code)]
 pub const UBI_SERVICES_URL: &str = "https://public-ubiservices.ubi.com";

--- a/siege-api/src/models.rs
+++ b/siege-api/src/models.rs
@@ -23,7 +23,7 @@ pub struct PlayerProfile {
 }
 
 /// Represents the different platforms that it is possible to play Siege on.
-#[derive(Debug, Deserialize, Serialize, EnumIter)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, EnumIter)]
 #[serde(rename_all = "lowercase")]
 pub enum PlatformType {
     Uplay,

--- a/siege-api/src/models/playerstats.rs
+++ b/siege-api/src/models/playerstats.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::*;
 
-#[derive(Debug, Clone, Copy, strum::Display, strum::EnumString, strum::EnumIter)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumString, strum::EnumIter)]
 pub enum SideOrAll {
     All,
     Attacker,
@@ -245,6 +245,72 @@ impl Statistics {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn side_or_all_debug() {
+        assert_eq!(format!("{:?}", SideOrAll::All), "All");
+        assert_eq!(format!("{:?}", SideOrAll::Attacker), "Attacker");
+        assert_eq!(format!("{:?}", SideOrAll::Defender), "Defender");
+    }
+
+    #[test]
+    fn side_or_all_display() {
+        assert_eq!(format!("{}", SideOrAll::All), "All");
+        assert_eq!(format!("{}", SideOrAll::Attacker), "Attacker");
+        assert_eq!(format!("{}", SideOrAll::Defender), "Defender");
+    }
+
+    #[test]
+    fn from_side_to_side_or_all() {
+        assert_eq!(Into::<SideOrAll>::into(Side::Attacker), SideOrAll::Attacker);
+        assert_eq!(Into::<SideOrAll>::into(Side::Defender), SideOrAll::Defender);
+    }
+
+    #[test]
+    fn get_statistics_from_sides() {
+        use strum::IntoEnumIterator;
+
+        let content = std::fs::read_to_string("../samples/operators.json").unwrap();
+        let stats: StatisticResponse = serde_json::from_str(content.as_str()).unwrap();
+
+        // Assert this will return valid statistics for the given side.
+        SideOrAll::iter().for_each(|side| {
+            stats.get_statistics_from_side(side).unwrap();
+        });
+    }
+
+    #[test]
+    fn get_operator() {
+        let content = std::fs::read_to_string("../samples/operators.json").unwrap();
+        let stats: StatisticResponse = serde_json::from_str(content.as_str()).unwrap();
+
+        let operator = stats.get_operator(Operator::Hibana).unwrap();
+
+        assert_eq!(operator.name, Operator::Hibana);
+        assert_eq!(*operator.statistics.matches_played(), 3);
+    }
+
+    #[test]
+    fn get_map() {
+        let content = std::fs::read_to_string("../samples/maps.json").unwrap();
+        let stats: StatisticResponse = serde_json::from_str(content.as_str()).unwrap();
+
+        let map = stats.get_map(Map::Yacht).unwrap();
+
+        assert_eq!(map.name, Map::Yacht);
+        assert_eq!(*map.statistics.matches_played(), 20);
+    }
+
+    #[test]
+    fn statistics_win_rates() {
+        let content = std::fs::read_to_string("../samples/operators.json").unwrap();
+        let stats: StatisticResponse = serde_json::from_str(content.as_str()).unwrap();
+        let operator = stats.get_operator(Operator::Ying).unwrap();
+
+        assert_eq!(operator.statistics().opening_win_rate(), 0.6785714285714286);
+        assert_eq!(operator.statistics().matches_win_rate(), 0.5657894736842105);
+        assert_eq!(operator.statistics().rounds_win_rate(), 0.48);
+    }
 
     #[test]
     fn deserialize_general_statistics() {

--- a/siege-api/src/models/playerstats.rs
+++ b/siege-api/src/models/playerstats.rs
@@ -410,10 +410,7 @@ mod test {
 
         let statistic: GeneralStatistics = serde_json::from_str(sample).unwrap();
 
-        match statistic {
-            GeneralStatistics::Operator(_) => {}
-            _ => assert!(false),
-        }
+        assert!(matches!(statistic, GeneralStatistics::Operator(_)));
     }
 
     #[test]
@@ -461,9 +458,6 @@ mod test {
 
         let statistic: GeneralStatistics = serde_json::from_str(sample).unwrap();
 
-        match statistic {
-            GeneralStatistics::Maps(_) => {}
-            _ => assert!(false),
-        }
+        assert!(matches!(statistic, GeneralStatistics::Maps(_)));
     }
 }

--- a/siege-bot/Cargo.toml
+++ b/siege-bot/Cargo.toml
@@ -24,3 +24,6 @@ async-trait = "0.1.68"
 duplicate = "1.0.0"
 strum = "0.24.1"
 serde_json = "1.0.95"
+
+[dev-dependencies]
+tempfile = "3.5.0"

--- a/siege-bot/src/main.rs
+++ b/siege-bot/src/main.rs
@@ -157,7 +157,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         data.insert::<SiegeApi>(siege_client);
     }
     {
-        let lookup = PlayerLookup::load()?;
+        let lookup = PlayerLookup::load(".players.json")?;
         let mut data = client.data.write().await;
         data.insert::<SiegePlayerLookup>(Arc::new(RwLock::new(lookup)));
     }

--- a/siege-bot/src/siege_player_lookup.rs
+++ b/siege-bot/src/siege_player_lookup.rs
@@ -115,4 +115,17 @@ mod test {
 
         assert_eq!(siege_id, retrieved_siege_id);
     }
+
+    #[test]
+    fn debug() {
+        let lookup = PlayerLookup {
+            filename: "some name".to_string(),
+            users: HashMap::default(),
+        };
+
+        assert_eq!(
+            format!("{lookup:?}"),
+            "PlayerLookup { filename: \"some name\", users: {} }"
+        );
+    }
 }


### PR DESCRIPTION
Increase the test coverage on the siege-api crate. All functionality should now be covered, with only the refresh auth flow missing. 

## Changelog

- test: Cleanup unimplemented functions on client
- test: Increased coverage for models
- test: Increased coverage for siege_player_lookup
- test: Changed client test singleton into reusing the same auth but indivdual clients
- test: Coverage on player stats functions
- test: refactored assertions on matches
