### PR TITLE
Add tests to autocomplete handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ All relevant checks for the code will be done and validated through Github workf
 
 ### Tests
 
-To run all the tests, the environment variables for Ubisoft have to set, as it is required to testing the interaction with the API. Some of these have been marked as `ignored` for now to not run them in the pipeline. This is mostly because Ubisoft do not like me logging in from many different places and closes the account 😫
+To run all the tests, the environment variables for Ubisoft have to set, as it is required to testing the interaction with the API.

--- a/siege-bot/src/commands.rs
+++ b/siege-bot/src/commands.rs
@@ -2,7 +2,10 @@ use async_trait::async_trait;
 use serenity::{builder::CreateApplicationCommand, model::prelude::command::CommandOptionType};
 use thiserror::Error;
 
-use self::{context::DiscordContext, discord_app_command::DiscordAppCmd};
+use self::{
+    context::DiscordContext,
+    discord_app_command::{DiscordAppCmd, DiscordAutocompleteInteraction},
+};
 
 pub mod add_player;
 pub mod all_maps;
@@ -23,6 +26,14 @@ pub trait CommandHandler {
     where
         Ctx: DiscordContext + Send + Sync,
         Cmd: DiscordAppCmd + 'static + Send + Sync;
+}
+
+#[async_trait]
+pub trait AutocompleteHandler {
+    async fn handle_autocomplete<Ctx, Cmd>(ctx: &Ctx, cmd: &Cmd) -> CmdResult
+    where
+        Ctx: DiscordContext + Send + Sync,
+        Cmd: DiscordAutocompleteInteraction + Send + Sync;
 }
 
 #[derive(Debug, Error)]

--- a/siege-bot/src/constants.rs
+++ b/siege-bot/src/constants.rs
@@ -1,1 +1,2 @@
 pub static NAME: &str = "name";
+pub static AUTOCOMPLETE_LIMIT: usize = 25;

--- a/siege-bot/src/handler.rs
+++ b/siege-bot/src/handler.rs
@@ -7,7 +7,7 @@ use serenity::{
 use crate::commands::{
     add_player::AddPlayerCommand, all_maps::AllMapsCommand, all_operators::AllOperatorCommand,
     id::IdCommand, map::MapCommand, operator::OperatorCommand, ping::PingCommand,
-    statistics::StatisticsCommand, CommandError, CommandHandler,
+    statistics::StatisticsCommand, AutocompleteHandler, CommandError, CommandHandler,
 };
 
 #[derive(Default)]


### PR DESCRIPTION
Refactoring autocomplete handlers so these can be tested as well. Introduces a wrapper for the `AutocompleteInteraction` from Serenity to make it mockable.

## Changelog

- docs: Removed note on CI with credentials
- test: Refactored autocomplete handlers to make testable
