### PR TITLE
Writing logs to file + tagging docker builds with bot version

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+
+name: changelog
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    name: check changelog
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Zomzog/changelog-checker@v1.3.0
+        with:
+          fileName: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,8 +13,6 @@ jobs:
     name: stable / fmt
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - name: Install stable
         uses: actions-rs/toolchain@v1
         with:
@@ -36,8 +34,6 @@ jobs:
         toolchain: [stable]
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - name: Install ${{ matrix.toolchain }}
         uses: actions-rs/toolchain@v1
         with:
@@ -49,4 +45,3 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -20,6 +20,10 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      - name: Get bot version
+        id: bot-version
+        run: echo "version=$(cat siege-bot/Cargo.toml | grep version | head -n1 | grep -o "\".*\"" | tr -d '"')" >> "$GITHUB_OUTPUT"
+
       - name: Login to container registry
         uses: redhat-actions/podman-login@v1
         with:
@@ -32,7 +36,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: siege-bot
-          tags: latest ${{ github.sha }}
+          tags: latest ${{ github.sha }} ${{ steps.bot-version.outputs.version }}
           platforms: linux/amd64
           containerfiles: Dockerfile
           layers: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Cargo.lock
 .envrc
 .players.json
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .envrc
 .players.json
 logs/
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Writing logs to file, customizable with environment var `LOGS_DIR`
+
+## [0.3.0]
+
+### Added
+
+- Command to get the status of Siege's servers with `/status`
+
+## [0.2.0]
+
+### Added
+
+- Command to sending player statistics to Discord
+- Command to send maps statistisc to Discord with `/map <map_name>`
+- Command to send operator statistics to Discord with `/operator <name>`
+- Linking Siege players with their Discord account with `/add`
+- Command to send statistics about all maps for a given player, with multiple sorting options
+- Command to send statistics about all operators for a given player, with a side and multiple sorting options
+- Autocomplete for entering map and operator names
+
+## [0.1.0]
+
+### Added
+
 - Small framework for Discord bot.
 - Simple ping and ID command to verify command is alive.
 - API: Retrieving statistics from players through the ranked v2 endpoint.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.68.0 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.69.0 AS chef
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The bot can then be run with from the root of the repository with `cargo run sie
 
 In order to link Discord IDs to Ubisoft accounts between restarts, the bot will store these relationships in a json file. It will first look relative to itself for `.players.json` or secondly at `/config/.players.json`. The second one was added to support mounting the file inside a container.
 
+### Logs
+
+Logs will by default be outputted to stdout and written to daily rolling files in `./logs/`. This directory can be customized by setting `LOGS_DIR` in the environment.
+
 ## Running inside container
 
 To run the bot as a container, the following comand can be used:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In order to link Discord IDs to Ubisoft accounts between restarts, the bot will 
 
 ### Logs
 
-Logs will by default be outputted to stdout and written to daily rolling files in `./logs/`. This directory can be customized by setting `LOGS_DIR` in the environment.
+Logs will by default be outputted to stdout and written to daily rolling files in `./logs/`. This directory can be customized by setting `LOGS_DIR` in the environment. If running inside a container, this must be mounted to a host machines directory to be persisted.
 
 ## Running inside container
 

--- a/scripts/clean-coverage.sh
+++ b/scripts/clean-coverage.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-find . -name "*.profraw" -type f -delete

--- a/siege-api/Cargo.toml
+++ b/siege-api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "siege-api"
 version = "0.3.0"
 edition = "2021"
-rust-version = "1.68"
+rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]
 
 [dependencies]

--- a/siege-bot/Cargo.toml
+++ b/siege-bot/Cargo.toml
@@ -24,6 +24,7 @@ async-trait = "0.1.68"
 duplicate = "1.0.0"
 strum = "0.24.1"
 serde_json = "1.0.95"
+tracing-appender = "0.2.2"
 
 [dev-dependencies]
 chrono = "0.4.24"

--- a/siege-bot/Cargo.toml
+++ b/siege-bot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "siege-bot"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-rust-version = "1.68"
+rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]
 publish = false
 


### PR DESCRIPTION
- Updates the bot to output logs to files, rolling over each day. As no that many commands are comming through, this should be a fine default for now. Instructions on how to set the directory has been added to the README.
- Updated the CI pipeline to verify `CHANGELOG.md` has been updated for each PR, unless it is labelled with `no changelog`.
- Publishing container images now includes the bot version as a tag.
- Bumped to use Rust `1.69.0`.

## Changelog

- feat: Write logs to files
- chore: Ignore `logs` directory
- docs: Updated README with logs + CHANGELOG for last few missing changes
- docs: How to mount logs
- chore: Bump docker rust version
- ci: Add check to see if changelog has been updated
- ci: Adding label to docker image with the bot version
- chore: Bumped bot version + using Rust 1.69
- chore: Removed unused script
