### PR TITLE
API client update to return raw RankedV2 response + options for game mode and platform for `statistics` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0]
+
+### Changed
+
+- Statistics client API now returns top level data, with getters to retreive relevant data.
+- Added choices for gamemode and platform for Discord `statistics` command
+
 ## [0.4.0]
 
 ### Added
@@ -22,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Command to sending player statistics to Discord
-- Command to send maps statistisc to Discord with `/map <map_name>`
+- Command to send maps statistics to Discord with `/map <map_name>`
 - Command to send operator statistics to Discord with `/operator <name>`
 - Linking Siege players with their Discord account with `/add`
 - Command to send statistics about all maps for a given player, with multiple sorting options

--- a/siege-api/Cargo.toml
+++ b/siege-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-api"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]

--- a/siege-api/src/client.rs
+++ b/siege-api/src/client.rs
@@ -11,7 +11,7 @@ use crate::constants::{
 };
 use crate::models::meta::GameStatus;
 use crate::models::{
-    FullProfile, PlatformType, PlayerProfile, PlaytimeProfile, PlaytimeResponse, RankedV2Response,
+    PlatformType, PlayerProfile, PlaytimeProfile, PlaytimeResponse, RankedV2Response,
     StatisticResponse,
 };
 
@@ -24,7 +24,7 @@ pub trait SiegeClient: Sync + Send {
 
     async fn get_playtime(&self, player_id: Uuid) -> Result<PlaytimeProfile>;
 
-    async fn get_full_profiles(&self, player_id: Uuid) -> Result<Vec<FullProfile>>;
+    async fn get_full_profiles(&self, player_id: Uuid) -> Result<RankedV2Response>;
 
     async fn get_operators(&self, player_id: Uuid) -> Result<StatisticResponse>;
 
@@ -104,7 +104,7 @@ impl SiegeClient for Client {
     /// Get full Siege profiles from the API. This will only contain the latest
     /// statistics from the current season. It does *not* look like it is possible
     /// to query earlier seasons at the moment.
-    async fn get_full_profiles(&self, player_id: Uuid) -> Result<Vec<FullProfile>> {
+    async fn get_full_profiles(&self, player_id: Uuid) -> Result<RankedV2Response> {
         let url = Url::parse_with_params(
             format!(
                 "{UBI_SERVICES_URL}/v2/spaces/{DEFAULT_SPACE_ID}/title/r6s/skill/full_profiles"
@@ -124,11 +124,7 @@ impl SiegeClient for Client {
             ConnectError::UnexpectedResponse
         })?;
 
-        Ok(profile.platform_families_full_profiles()[0]
-            .board_ids_full_profiles()
-            .iter()
-            .map(|x| x.full_profiles()[0])
-            .collect::<Vec<_>>())
+        Ok(profile)
     }
 
     /// Retreive statistics about operators for a given player.

--- a/siege-api/src/models.rs
+++ b/siege-api/src/models.rs
@@ -296,7 +296,7 @@ mod mappers {
         if value.is_empty() {
             Ok(None)
         } else {
-            Uuid::parse_str(&value).map(Some).map_err(|err| {
+            Uuid::parse_str(value).map(Some).map_err(|err| {
                 serde::de::Error::custom(format!(
                     "cannot convert string value '{value}' to an uuid. Err: {err}"
                 ))

--- a/siege-api/src/models.rs
+++ b/siege-api/src/models.rs
@@ -127,6 +127,12 @@ impl RankedV2Response {
             .iter()
             .find(|x| x.platform_family == platform)
     }
+
+    /// Get the statistics board for a given platform family and play type.
+    pub fn get_board(&self, platform: PlatformFamily, play_type: PlayType) -> Option<&Board> {
+        self.get_for_platform(platform)
+            .and_then(|x| x.get_by_playtype(play_type))
+    }
 }
 
 #[derive(Debug, Deserialize, Getters, PartialEq, Eq)]
@@ -367,6 +373,24 @@ mod test {
         assert_eq!(
             platforms.board_ids_full_profiles.get(3),
             platforms.get_by_playtype(PlayType::Ranked)
+        );
+    }
+
+    #[test]
+    fn ranked_v2_get_board_by_platform_and_play_type() {
+        let content = read_to_string("../samples/full_profile.json").unwrap();
+        let response: RankedV2Response = serde_json::from_str(content.as_str()).unwrap();
+
+        let expected = response
+            .platform_families_full_profiles
+            .get(0)
+            .unwrap()
+            .board_ids_full_profiles
+            .get(3);
+
+        assert_eq!(
+            response.get_board(PlatformFamily::Pc, PlayType::Ranked),
+            expected
         );
     }
 

--- a/siege-api/src/models.rs
+++ b/siege-api/src/models.rs
@@ -129,9 +129,10 @@ impl RankedV2Response {
     }
 
     /// Get the statistics board for a given platform family and play type.
-    pub fn get_board(&self, platform: PlatformFamily, play_type: PlayType) -> Option<&Board> {
+    pub fn get_board(&self, platform: PlatformFamily, play_type: PlayType) -> Option<&FullProfile> {
         self.get_for_platform(platform)
             .and_then(|x| x.get_by_playtype(play_type))
+            .and_then(|x| x.full_profiles.get(0))
     }
 }
 
@@ -384,9 +385,8 @@ mod test {
         let expected = response
             .platform_families_full_profiles
             .get(0)
-            .unwrap()
-            .board_ids_full_profiles
-            .get(3);
+            .and_then(|x| x.board_ids_full_profiles.get(3))
+            .and_then(|x| x.full_profiles.get(0));
 
         assert_eq!(
             response.get_board(PlatformFamily::Pc, PlayType::Ranked),

--- a/siege-bot/Cargo.toml
+++ b/siege-bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-bot"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]

--- a/siege-bot/src/commands.rs
+++ b/siege-bot/src/commands.rs
@@ -71,7 +71,9 @@ pub(crate) mod test {
 
     use async_trait::async_trait;
     use serenity::prelude::{RwLock, TypeMap};
-    use siege_api::models::{meta::GameStatus, FullProfile, PlaytimeProfile, StatisticResponse};
+    use siege_api::models::{
+        meta::GameStatus, PlaytimeProfile, RankedV2Response, StatisticResponse,
+    };
     use uuid::Uuid;
 
     use crate::SiegeApi;
@@ -86,7 +88,7 @@ pub(crate) mod test {
         impl siege_api::client::SiegeClient for SiegeClient {
             async fn search_for_player(&self, name: &str) -> siege_api::client::Result<Uuid>;
             async fn get_playtime(&self, player_id: Uuid) -> siege_api::client::Result<PlaytimeProfile>;
-            async fn get_full_profiles(&self, player_id: Uuid) -> siege_api::client::Result<Vec<FullProfile>>;
+            async fn get_full_profiles(&self, player_id: Uuid) -> siege_api::client::Result<RankedV2Response>;
             async fn get_operators(&self, player_id: Uuid) -> siege_api::client::Result<StatisticResponse>;
             async fn get_maps(&self, player_id: Uuid) -> siege_api::client::Result<StatisticResponse>;
             async fn siege_status(&self) -> siege_api::client::Result<Vec<GameStatus>>;

--- a/siege-bot/src/commands/game_status.rs
+++ b/siege-bot/src/commands/game_status.rs
@@ -66,7 +66,7 @@ impl CommandHandler for GameStatusCommand {
                         game_status
                             .iter()
                             .map(|x| x.name())
-                            .fold(String::new(), |acc, next| acc + &next + "\n"),
+                            .fold(String::new(), |acc, next| acc + next + "\n"),
                         true,
                     )
                     .field(
@@ -85,7 +85,7 @@ impl CommandHandler for GameStatusCommand {
                                 .flat_map(|x| x.impacted_features())
                                 .collect::<HashSet<_>>()
                                 .iter()
-                                .fold(String::new(), |acc, next| acc + &next + "\n"),
+                                .fold(String::new(), |acc, next| acc + next + "\n"),
                         )
                         .filter(|s| !s.is_empty())
                         .unwrap_or_else(|| "None".to_string()),

--- a/siege-bot/src/commands/statistics.rs
+++ b/siege-bot/src/commands/statistics.rs
@@ -1,8 +1,11 @@
 use async_trait::async_trait;
 use serenity::{
     builder::{CreateApplicationCommand, CreateEmbed},
+    model::prelude::command::CommandOptionType,
     utils::Color,
 };
+use siege_api::models::{GameMode, PlatformFamily};
+use strum::IntoEnumIterator;
 
 use crate::SiegeApi;
 
@@ -10,6 +13,9 @@ use super::{
     context::DiscordContext, discord_app_command::DiscordAppCmd, AddUserOptionToCommand, CmdResult,
     CommandHandler,
 };
+
+const PLATFORM: &str = "platform";
+const GAME_MODE: &str = "game_mode";
 
 pub struct StatisticsCommand;
 
@@ -19,6 +25,32 @@ impl CommandHandler for StatisticsCommand {
         command
             .name("statistics")
             .description("Get the statistics for a Siege player")
+            .create_option(|option| {
+                option
+                    .name(PLATFORM)
+                    .description("Platform to retrieve player's data from")
+                    .kind(CommandOptionType::String)
+                    .required(false);
+
+                PlatformFamily::iter().for_each(|x| {
+                    option.add_string_choice(x.to_string(), x.to_string());
+                });
+
+                option
+            })
+            .create_option(|option| {
+                option
+                    .name(GAME_MODE)
+                    .description("Game mode to get statistics for")
+                    .kind(CommandOptionType::String)
+                    .required(false);
+
+                GameMode::iter().for_each(|x| {
+                    option.add_string_choice(x.to_string(), x.to_string());
+                });
+
+                option
+            })
             .add_user_option()
     }
 
@@ -29,10 +61,16 @@ impl CommandHandler for StatisticsCommand {
     {
         let user = command.get_user_from_command_or_default();
         let player_id = ctx.lookup_siege_player(command, &user).await?;
+        let platform = command
+            .extract_enum_option(PLATFORM)
+            .unwrap_or(PlatformFamily::Pc);
+        let game_mode = command
+            .extract_enum_option(GAME_MODE)
+            .unwrap_or(GameMode::Casual);
 
         tracing::info!("Getting statistics for {}", user.name);
 
-        let profiles = {
+        let statistics = {
             let data = ctx.data().read().await;
             let siege_client = data
                 .get::<SiegeApi>()
@@ -46,42 +84,56 @@ impl CommandHandler for StatisticsCommand {
             }
         };
 
-        let profile: siege_api::models::FullProfile = profiles[0];
+        match statistics.get_board(platform, game_mode) {
+            Some(data) => {
+                let season = *data.season_statistics();
+                let matches = *season.match_outcomes();
 
-        let season = *profile.season_statistics();
-        let matches = *season.match_outcomes();
-
-        command
-            .send_embedded(
-                ctx.http().clone(),
-                CreateEmbed::default()
-                    .title(format!("Statistics for {}", user.name))
-                    .thumbnail(user.avatar_url().unwrap())
-                    .field(
-                        "Kill/death",
+                command
+                .send_embedded(
+                    ctx.http().clone(),
+                    CreateEmbed::default()
+                        .title(format!("Statistics for {}", user.name))
+                        .thumbnail(user.avatar_url().unwrap())
+                        .field(
+                            "Kill/death",
+                            format!(
+                                "K/D: **{kd:.2}** - Kills {kills} / Deaths {deaths}",
+                                kd = season.kd(),
+                                kills = season.kills(),
+                                deaths = season.deaths(),
+                            ),
+                            false,
+                        )
+                        .field(
+                            "Match",
+                            format!(
+                                "Matches {total} - **{win_rate:.2} %** - Wins **{wins}** / Losses **{losses}**",
+                                total = matches.total_matches(),
+                                wins = matches.wins(),
+                                losses = matches.losses(),
+                                win_rate = matches.win_rate() * 100.0,
+                            ),
+                            false,
+                        )
+                        .color(Color::DARK_RED)
+                        .clone(),
+                )
+                .await
+            }
+            None => {
+                command
+                    .send_text(
+                        ctx.http().clone(),
                         format!(
-                            "K/D: **{kd:.2}** - Kills {kills} / Deaths {deaths}",
-                            kd = season.kd(),
-                            kills = season.kills(),
-                            deaths = season.deaths(),
-                        ),
-                        false,
+                            "No data found for {platform}/{game_mode} for player {}",
+                            user.tag()
+                        )
+                        .as_str(),
                     )
-                    .field(
-                        "Match",
-                        format!(
-                            "Matches {total} - **{win_rate:.2} %** - Wins **{wins}** / Losses **{losses}**",
-                            total = matches.total_matches(),
-                            wins = matches.wins(),
-                            losses = matches.losses(),
-                            win_rate = matches.win_rate() * 100.0,
-                        ),
-                        false,
-                    )
-                    .color(Color::DARK_RED)
-                    .clone(),
-            )
-            .await
+                    .await
+            }
+        }
     }
 }
 
@@ -116,7 +168,22 @@ mod test {
             .is_empty());
 
         let options = command.0.get("options").unwrap().as_array().unwrap();
+
         let opt = options.get(0).unwrap();
+        assert_eq!(opt.get("name").unwrap(), PLATFORM);
+        assert_eq!(*opt.get("required").unwrap(), Value::Bool(false));
+        assert_eq!(opt.get("type").unwrap().as_u64().unwrap(), 3); // Corresponds to `CommandOptionType::User`
+        assert!(!opt.get("description").unwrap().as_str().unwrap().is_empty());
+        assert_eq!(opt.get("choices").unwrap().as_array().unwrap().len(), 2);
+
+        let opt = options.get(1).unwrap();
+        assert_eq!(opt.get("name").unwrap(), GAME_MODE);
+        assert_eq!(*opt.get("required").unwrap(), Value::Bool(false));
+        assert_eq!(opt.get("type").unwrap().as_u64().unwrap(), 3); // Corresponds to `CommandOptionType::User`
+        assert!(!opt.get("description").unwrap().as_str().unwrap().is_empty());
+        assert_eq!(opt.get("choices").unwrap().as_array().unwrap().len(), 4);
+
+        let opt = options.get(2).unwrap();
         assert_eq!(opt.get("name").unwrap(), "user");
         assert_eq!(*opt.get("required").unwrap(), Value::Bool(false));
         assert_eq!(opt.get("type").unwrap().as_u64().unwrap(), 6); // Corresponds to `CommandOptionType::User`
@@ -128,40 +195,52 @@ mod test {
         let user = User::default();
         let siege_id = Uuid::new_v4();
 
-        let mut ctx = MockDiscordContext::new();
-        ctx.expect_http().return_const(None);
-        ctx.expect_lookup_siege_player::<MockDiscordAppCmd>()
-            .with(always(), eq(user.clone()))
-            .once()
-            .returning(move |_, _| Ok(siege_id));
+        for game_mode in vec![
+            GameMode::Casual,
+            GameMode::Event,
+            GameMode::Ranked,
+            GameMode::Warmup,
+        ] {
+            let mut ctx = MockDiscordContext::new();
+            ctx.expect_http().return_const(None);
+            ctx.expect_lookup_siege_player::<MockDiscordAppCmd>()
+                .with(always(), eq(user.clone()))
+                .once()
+                .returning(move |_, _| Ok(siege_id));
 
-        let mut mock_client = MockSiegeClient::default();
-        mock_client
-            .expect_get_full_profiles()
-            .once()
-            .returning(|_| {
-                let content = std::fs::read_to_string("../samples/full_profile.json").unwrap();
-                let stats: RankedV2Response = serde_json::from_str(content.as_str()).unwrap();
-                Ok(stats.platform_families_full_profiles()[0]
-                    .board_ids_full_profiles()
-                    .iter()
-                    .map(|x| x.full_profiles()[0])
-                    .collect::<Vec<_>>())
-            });
-        register_client_in_type_map(&mut ctx, mock_client).await;
+            let mut mock_client = MockSiegeClient::default();
+            mock_client
+                .expect_get_full_profiles()
+                .once()
+                .returning(|_| {
+                    let content = std::fs::read_to_string("../samples/full_profile.json").unwrap();
+                    let stats: RankedV2Response = serde_json::from_str(content.as_str()).unwrap();
+                    Ok(stats)
+                });
+            register_client_in_type_map(&mut ctx, mock_client).await;
 
-        let mut command = MockDiscordAppCmd::new();
-        command
-            .expect_get_user_from_command_or_default()
-            .return_const(user.clone());
-        command
-            .expect_send_embedded()
-            .once()
-            .with(always(), always())
-            .returning(|_, _| Ok(()));
+            let mut command = MockDiscordAppCmd::new();
+            command
+                .expect_get_user_from_command_or_default()
+                .return_const(user.clone());
+            command
+                .expect_extract_enum_option()
+                .with(eq(GAME_MODE))
+                .return_once(move |_| Some(game_mode));
+            command
+                .expect_extract_enum_option()
+                .with(eq(PLATFORM))
+                .return_once(|_| Some(PlatformFamily::Pc));
 
-        // Act
-        assert!(StatisticsCommand::run(&ctx, &command).await.is_ok());
+            command
+                .expect_send_embedded()
+                .once()
+                .with(always(), always())
+                .returning(|_, _| Ok(()));
+
+            // Act
+            assert!(StatisticsCommand::run(&ctx, &command).await.is_ok());
+        }
     }
 
     #[tokio::test]
@@ -188,9 +267,72 @@ mod test {
             .expect_get_user_from_command_or_default()
             .return_const(user.clone());
         command
+            .expect_extract_enum_option()
+            .with(eq(GAME_MODE))
+            .return_once(move |_| Some(GameMode::Casual));
+        command
+            .expect_extract_enum_option()
+            .with(eq(PLATFORM))
+            .return_once(|_| Some(PlatformFamily::Pc));
+
+        command
             .expect_send_text()
             .once()
             .with(always(), eq("Failed to fetch data"))
+            .returning(|_, _| Ok(()));
+
+        // Act
+        assert!(StatisticsCommand::run(&ctx, &command).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn validate_run_no_statistics_for_choices() {
+        let user = User::default();
+        let siege_id = Uuid::new_v4();
+
+        let mut ctx = MockDiscordContext::new();
+        ctx.expect_http().return_const(None);
+        ctx.expect_lookup_siege_player::<MockDiscordAppCmd>()
+            .with(always(), eq(user.clone()))
+            .once()
+            .returning(move |_, _| Ok(siege_id));
+
+        let mut mock_client = MockSiegeClient::default();
+        mock_client
+            .expect_get_full_profiles()
+            .once()
+            .returning(|_| {
+                let content = std::fs::read_to_string("../samples/full_profile.json").unwrap();
+                let stats: RankedV2Response = serde_json::from_str(content.as_str()).unwrap();
+                Ok(stats)
+            });
+        register_client_in_type_map(&mut ctx, mock_client).await;
+
+        let mut command = MockDiscordAppCmd::new();
+        command
+            .expect_get_user_from_command_or_default()
+            .return_const(user.clone());
+        command
+            .expect_extract_enum_option()
+            .with(eq(GAME_MODE))
+            .return_once(move |_| Some(GameMode::Casual));
+        command
+            .expect_extract_enum_option()
+            .with(eq(PLATFORM))
+            .return_once(|_| Some(PlatformFamily::Console));
+
+        command
+            .expect_send_text()
+            .once()
+            .with(
+                always(),
+                eq(format!(
+                    "No data found for {}/{} for player {}",
+                    PlatformFamily::Console,
+                    GameMode::Casual,
+                    user.tag()
+                )),
+            )
             .returning(|_, _| Ok(()));
 
         // Act

--- a/siege-bot/src/commands/statistics.rs
+++ b/siege-bot/src/commands/statistics.rs
@@ -48,8 +48,8 @@ impl CommandHandler for StatisticsCommand {
 
         let profile: siege_api::models::FullProfile = profiles[0];
 
-        let season = profile.season_statistics().clone();
-        let matches = season.match_outcomes().clone();
+        let season = *profile.season_statistics();
+        let matches = *season.match_outcomes();
 
         command
             .send_embedded(


### PR DESCRIPTION
API client has been refactored to better allow getting data from the RankedV2 API. Using this updated api, the `statistics` command has been updated to allow the client to supply options for which platform and game mode they want to see data for.

## Changelog

- refactor: Getter for RankedV2 with platform
- feat: Getter to retrieve board by play type
- feat: Function to retrive boards directly from `RankedV2Response`
- fix: Clippy warnings
- refactor: Returning FullProfile instead of Board
- feat: Updated statistics command with platform and game mode options
- chore: Bumped version numbers and updated changelog
