### PR TITLE
Update `all_*` commands to have `game_mode` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0]
+
+### Changed
+
+- `all_maps` and `all_operators` now includes a `game_mode` option for either `all` or `ranked` to filter data.
+
 ## [0.5.1]
 
 ### Changed

--- a/siege-api/Cargo.toml
+++ b/siege-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-api"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]

--- a/siege-bot/Cargo.toml
+++ b/siege-bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-bot"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]

--- a/siege-bot/src/commands.rs
+++ b/siege-bot/src/commands.rs
@@ -2,6 +2,8 @@ use async_trait::async_trait;
 use serenity::{builder::CreateApplicationCommand, model::prelude::command::CommandOptionType};
 use thiserror::Error;
 
+use crate::constants::USER;
+
 use self::{
     context::DiscordContext,
     discord_app_command::{DiscordAppCmd, DiscordAutocompleteInteraction},
@@ -57,7 +59,7 @@ impl AddUserOptionToCommand for CreateApplicationCommand {
     fn add_user_option(&mut self) -> &mut CreateApplicationCommand {
         self.create_option(|option| {
             option
-                .name("user")
+                .name(USER)
                 .description("The user to get statistics for. Defaults to the sending user")
                 .kind(CommandOptionType::User)
                 .required(false)

--- a/siege-bot/src/commands/all_maps.rs
+++ b/siege-bot/src/commands/all_maps.rs
@@ -144,7 +144,10 @@ impl CommandHandler for AllMapsCommand {
                 ctx.http(),
                 CreateEmbed::default()
                     .thumbnail(user.avatar_url().unwrap_or_default())
-                    .title(format!("{} map statistics for {}", side, user.name))
+                    .title(format!(
+                        "{}/{} map statistics for {}",
+                        game_mode, side, user.name
+                    ))
                     .color(Color::TEAL)
                     .format(&maps)
                     .to_owned(),

--- a/siege-bot/src/commands/all_maps.rs
+++ b/siege-bot/src/commands/all_maps.rs
@@ -6,10 +6,10 @@ use serenity::{
     },
     utils::Color,
 };
-use siege_api::models::{MapStatistics, SideOrAll};
+use siege_api::models::{AllOrRanked, MapStatistics, SideOrAll};
 use strum::IntoEnumIterator;
 
-use crate::{formatting::FormatEmbedded, SiegeApi};
+use crate::{constants::GAME_MODE, formatting::FormatEmbedded, SiegeApi};
 
 use super::{
     context::DiscordContext, discord_app_command::DiscordAppCmd, AddUserOptionToCommand, CmdResult,
@@ -70,6 +70,19 @@ impl CommandHandler for AllMapsCommand {
                     .kind(CommandOptionType::Integer)
                     .required(false)
             })
+            .create_option(|option| {
+                option
+                    .name(GAME_MODE)
+                    .description("Game mode to retreive statistics for")
+                    .kind(CommandOptionType::String)
+                    .required(false);
+
+                AllOrRanked::iter().for_each(|mode| {
+                    option.add_string_choice(mode, mode);
+                });
+
+                option
+            })
             .add_user_option()
     }
 
@@ -91,6 +104,9 @@ impl CommandHandler for AllMapsCommand {
                 _ => None,
             })
             .unwrap_or(0);
+        let game_mode = command
+            .extract_enum_option(GAME_MODE)
+            .unwrap_or(AllOrRanked::All);
 
         let user = command.get_user_from_command_or_default();
         tracing::info!(
@@ -115,7 +131,7 @@ impl CommandHandler for AllMapsCommand {
         };
 
         let mut maps = response
-            .get_maps(side)
+            .get_maps(game_mode, side)
             .iter()
             .filter(|x| *x.statistics().rounds_played() as i64 >= minimum_rounds)
             .copied()
@@ -183,10 +199,13 @@ mod test {
     use siege_api::models::StatisticResponse;
     use uuid::Uuid;
 
-    use crate::commands::{
-        context::MockDiscordContext,
-        discord_app_command::MockDiscordAppCmd,
-        test::{register_client_in_type_map, MockSiegeClient},
+    use crate::{
+        commands::{
+            context::MockDiscordContext,
+            discord_app_command::MockDiscordAppCmd,
+            test::{register_client_in_type_map, MockSiegeClient},
+        },
+        constants::USER,
     };
 
     use super::*;
@@ -223,9 +242,16 @@ mod test {
         assert_eq!(opt.get("type").unwrap().as_u64().unwrap(), 4); // Corresponds to `CommandOptionType::Integer`
 
         let opt = options.get(3).unwrap();
-        assert_eq!(opt.get("name").unwrap(), "user");
+        assert_eq!(opt.get("name").unwrap(), GAME_MODE);
         assert_eq!(*opt.get("required").unwrap(), Value::Bool(false));
-        assert_eq!(opt.get("type").unwrap().as_u64().unwrap(), 6); // Corresponds to `CommandOptionType::Integer`
+        assert_eq!(opt.get("type").unwrap().as_u64().unwrap(), 3); // Corresponds to `CommandOptionType::String`
+        assert_eq!(opt.get("choices").unwrap().as_array().unwrap().len(), 2);
+        assert!(!opt.get("description").unwrap().as_str().unwrap().is_empty());
+
+        let opt = options.get(4).unwrap();
+        assert_eq!(opt.get("name").unwrap(), USER);
+        assert_eq!(*opt.get("required").unwrap(), Value::Bool(false));
+        assert_eq!(opt.get("type").unwrap().as_u64().unwrap(), 6);
         assert!(!opt.get("description").unwrap().as_str().unwrap().is_empty());
     }
 
@@ -235,13 +261,43 @@ mod test {
         let siege_id = Uuid::new_v4();
 
         // Testing different combinations of arguments.
-        for (side, sorting, rounds) in vec![
-            (Some(SideOrAll::All), None, Some(10 as i64)),
-            (Some(SideOrAll::Attacker), Some(Sorting::Kd), None),
-            (Some(SideOrAll::Defender), Some(Sorting::RoundsPlayed), None),
-            (Some(SideOrAll::All), Some(Sorting::RoundWinRate), None),
-            (Some(SideOrAll::All), Some(Sorting::MatchWinRate), None),
-            (Some(SideOrAll::All), Some(Sorting::MatchesPlayed), None),
+        for (side, sorting, rounds, game_mode) in vec![
+            (
+                Some(SideOrAll::All),
+                None,
+                Some(10 as i64),
+                Some(AllOrRanked::All),
+            ),
+            (
+                Some(SideOrAll::Attacker),
+                Some(Sorting::Kd),
+                None,
+                Some(AllOrRanked::Ranked),
+            ),
+            (
+                Some(SideOrAll::Defender),
+                Some(Sorting::RoundsPlayed),
+                None,
+                None,
+            ),
+            (
+                Some(SideOrAll::All),
+                Some(Sorting::RoundWinRate),
+                None,
+                None,
+            ),
+            (
+                Some(SideOrAll::All),
+                Some(Sorting::MatchWinRate),
+                None,
+                None,
+            ),
+            (
+                Some(SideOrAll::All),
+                Some(Sorting::MatchesPlayed),
+                None,
+                None,
+            ),
         ] {
             let mut ctx = MockDiscordContext::new();
             ctx.expect_http().return_const(None);
@@ -271,6 +327,10 @@ mod test {
                 .expect_get_option()
                 .with(eq(MINIMUM_ROUNDS))
                 .return_const(rounds.map(|x| CommandDataOptionValue::Integer(x)));
+            command
+                .expect_extract_enum_option::<AllOrRanked>()
+                .with(eq(GAME_MODE))
+                .return_const(game_mode);
             command
                 .expect_get_user_from_command_or_default()
                 .return_const(user.clone());
@@ -320,6 +380,10 @@ mod test {
         command
             .expect_get_option()
             .with(eq(MINIMUM_ROUNDS))
+            .return_const(None);
+        command
+            .expect_extract_enum_option::<AllOrRanked>()
+            .with(eq(GAME_MODE))
             .return_const(None);
         command
             .expect_get_user_from_command_or_default()

--- a/siege-bot/src/commands/all_operators.rs
+++ b/siege-bot/src/commands/all_operators.rs
@@ -137,7 +137,10 @@ impl CommandHandler for AllOperatorCommand {
                 ctx.http().clone(),
                 CreateEmbed::default()
                     .thumbnail(user.avatar_url().unwrap_or_default())
-                    .title(format!("{} operator statistics for {}", side, user.name))
+                    .title(format!(
+                        "{}/{} operator statistics for {}",
+                        game_mode, side, user.name
+                    ))
                     .color(Color::TEAL)
                     .format(&operators)
                     .to_owned(),

--- a/siege-bot/src/commands/all_operators.rs
+++ b/siege-bot/src/commands/all_operators.rs
@@ -6,9 +6,17 @@ use serenity::{
     },
     utils::Color,
 };
-use siege_api::{game_models::Side, models::OperatorStatistics};
+use siege_api::{
+    game_models::Side,
+    models::{AllOrRanked, OperatorStatistics},
+};
+use strum::IntoEnumIterator;
 
-use crate::{formatting::FormatEmbedded, SiegeApi};
+use crate::{
+    constants::{GAME_MODE, MINIMUM_ROUNDS, SIDE, SORTING},
+    formatting::FormatEmbedded,
+    SiegeApi,
+};
 
 use super::{
     context::DiscordContext, discord_app_command::DiscordAppCmd, AddUserOptionToCommand, CmdResult,
@@ -21,10 +29,6 @@ enum Sorting {
     WinRate,
     RoundsPlayed,
 }
-
-static SIDE: &str = "side";
-static SORTING: &str = "sorting";
-static MINIMUM_ROUNDS: &str = "minimum_rounds";
 
 pub struct AllOperatorCommand;
 
@@ -50,7 +54,6 @@ impl CommandHandler for AllOperatorCommand {
                     .kind(CommandOptionType::String)
                     .required(false);
 
-                use strum::IntoEnumIterator;
                 Sorting::iter().for_each(|sorting| {
                     option.add_string_choice(sorting, sorting);
                 });
@@ -63,6 +66,19 @@ impl CommandHandler for AllOperatorCommand {
                     .description("Ignore operators you have played for less than this limit")
                     .kind(CommandOptionType::Integer)
                     .required(false)
+            })
+            .create_option(|option| {
+                option
+                    .name(GAME_MODE)
+                    .description("Game mode to retreive statistics for")
+                    .kind(CommandOptionType::String)
+                    .required(false);
+
+                AllOrRanked::iter().for_each(|mode| {
+                    option.add_string_choice(mode, mode);
+                });
+
+                option
             })
             .add_user_option()
     }
@@ -82,6 +98,9 @@ impl CommandHandler for AllOperatorCommand {
                 _ => None,
             })
             .unwrap_or(0);
+        let game_mode = command
+            .extract_enum_option(GAME_MODE)
+            .unwrap_or(AllOrRanked::All);
 
         let user = command.get_user_from_command_or_default();
         tracing::info!(
@@ -106,7 +125,7 @@ impl CommandHandler for AllOperatorCommand {
         };
 
         let mut operators = operator_response
-            .get_operators(side.into())
+            .get_operators(game_mode, side.into())
             .iter()
             .filter(|op| *op.statistics().rounds_played() as i64 >= minimum_rounds)
             .copied()
@@ -172,6 +191,7 @@ mod test {
             discord_app_command::MockDiscordAppCmd,
             test::{register_client_in_type_map, MockSiegeClient},
         },
+        constants::USER,
         siege_player_lookup::{MockPlayerLookup, SiegePlayerLookup},
     };
 
@@ -209,7 +229,13 @@ mod test {
         assert_eq!(opt.get("type").unwrap().as_u64().unwrap(), 4); // Corresponds to `CommandOptionType::Integer`
 
         let opt = options.get(3).unwrap();
-        assert_eq!(opt.get("name").unwrap(), "user");
+        assert_eq!(opt.get("name").unwrap(), GAME_MODE);
+        assert_eq!(opt.get("type").unwrap().as_u64().unwrap(), 3); // Corresponds to `CommandOptionType::String`
+        assert_eq!(*opt.get("required").unwrap(), Value::Bool(false));
+        assert_eq!(opt.get("choices").unwrap().as_array().unwrap().len(), 2);
+
+        let opt = options.get(4).unwrap();
+        assert_eq!(opt.get("name").unwrap(), USER);
         assert_eq!(*opt.get("required").unwrap(), Value::Bool(false));
         assert_eq!(opt.get("type").unwrap().as_u64().unwrap(), 6); // Corresponds to `CommandOptionType::Integer`
         assert!(!opt.get("description").unwrap().as_str().unwrap().is_empty());
@@ -221,10 +247,20 @@ mod test {
         let siege_id = Uuid::new_v4();
 
         // Testing different combinations of arguments.
-        for (side, sorting, rounds) in vec![
-            (Some(Side::Attacker), Some(Sorting::Kd), Some(10 as i64)),
-            (Some(Side::Defender), Some(Sorting::RoundsPlayed), None),
-            (Some(Side::Defender), Some(Sorting::WinRate), None),
+        for (side, sorting, rounds, game_mode) in vec![
+            (
+                Some(Side::Attacker),
+                Some(Sorting::Kd),
+                Some(10 as i64),
+                Some(AllOrRanked::All),
+            ),
+            (
+                Some(Side::Defender),
+                Some(Sorting::RoundsPlayed),
+                None,
+                Some(AllOrRanked::Ranked),
+            ),
+            (Some(Side::Defender), Some(Sorting::WinRate), None, None),
         ] {
             // Ensure the expected message is sent back through the command
             let mut ctx = MockDiscordContext::new();
@@ -266,6 +302,10 @@ mod test {
                 .expect_get_option()
                 .with(eq(MINIMUM_ROUNDS))
                 .return_const(rounds.map(|x| CommandDataOptionValue::Integer(x)));
+            command
+                .expect_extract_enum_option::<AllOrRanked>()
+                .with(eq(GAME_MODE))
+                .return_const(game_mode);
             command
                 .expect_get_user_from_command_or_default()
                 .return_const(user.clone());
@@ -314,6 +354,10 @@ mod test {
         command
             .expect_get_option()
             .with(eq(MINIMUM_ROUNDS))
+            .return_const(None);
+        command
+            .expect_extract_enum_option::<AllOrRanked>()
+            .with(eq(GAME_MODE))
             .return_const(None);
         command
             .expect_get_user_from_command_or_default()

--- a/siege-bot/src/commands/statistics.rs
+++ b/siege-bot/src/commands/statistics.rs
@@ -10,15 +10,15 @@ use siege_api::{
 };
 use strum::IntoEnumIterator;
 
-use crate::SiegeApi;
+use crate::{
+    constants::{GAME_MODE, PLATFORM},
+    SiegeApi,
+};
 
 use super::{
     context::DiscordContext, discord_app_command::DiscordAppCmd, AddUserOptionToCommand, CmdResult,
     CommandHandler,
 };
-
-const PLATFORM: &str = "platform";
-const GAME_MODE: &str = "game_mode";
 
 pub struct StatisticsCommand;
 

--- a/siege-bot/src/constants.rs
+++ b/siege-bot/src/constants.rs
@@ -1,2 +1,9 @@
-pub static NAME: &str = "name";
-pub static AUTOCOMPLETE_LIMIT: usize = 25;
+pub const NAME: &str = "name";
+pub const USER: &str = "user";
+pub const PLATFORM: &str = "platform";
+pub const GAME_MODE: &str = "game_mode";
+pub const SIDE: &str = "side";
+pub const SORTING: &str = "sorting";
+pub const MINIMUM_ROUNDS: &str = "minimum_rounds";
+
+pub const AUTOCOMPLETE_LIMIT: usize = 25;

--- a/siege-bot/src/formatting/all_maps_format.rs
+++ b/siege-bot/src/formatting/all_maps_format.rs
@@ -42,7 +42,7 @@ mod test {
     use std::ops::Sub;
 
     use chrono::{DateTime, Utc};
-    use siege_api::models::{SideOrAll, StatisticResponse};
+    use siege_api::models::{AllOrRanked, SideOrAll, StatisticResponse};
 
     use super::*;
 
@@ -51,7 +51,7 @@ mod test {
         let mut embed = CreateEmbed::default();
         let content = std::fs::read_to_string("../samples/maps.json").unwrap();
         let stats: StatisticResponse = serde_json::from_str(content.as_str()).unwrap();
-        let maps = stats.get_maps(SideOrAll::All);
+        let maps = stats.get_maps(AllOrRanked::All, SideOrAll::All);
 
         embed.format(&maps);
 

--- a/siege-bot/src/formatting/all_maps_format.rs
+++ b/siege-bot/src/formatting/all_maps_format.rs
@@ -20,7 +20,7 @@ impl FormatEmbedded<'_, Vec<&MapStatistics>> for CreateEmbed {
             .iter()
             .map(|x| {
                 format!(
-                    "M: `{:.2} %` (`{}`) R: `{:.2} %` (`{}`)",
+                    "M: `{:.2} %` (`{}`) R: `{:.2} %` (`{: >3}`)",
                     100.0 * x.statistics().matches_win_rate(),
                     x.statistics().matches_played(),
                     100.0 * x.statistics().rounds_win_rate(),

--- a/siege-bot/src/formatting/all_operators_format.rs
+++ b/siege-bot/src/formatting/all_operators_format.rs
@@ -20,7 +20,7 @@ impl FormatEmbedded<'_, Vec<&OperatorStatistics>> for CreateEmbed {
             .iter()
             .map(|op| {
                 format!(
-                    "`{:.2} %` (of `{}`)",
+                    "`{: >6.2} %` (of `{: >3}`)",
                     100.0 * op.statistics().rounds_win_rate(),
                     op.statistics().rounds_played()
                 )

--- a/siege-bot/src/formatting/all_operators_format.rs
+++ b/siege-bot/src/formatting/all_operators_format.rs
@@ -40,7 +40,7 @@ mod test {
     use std::ops::Sub;
 
     use chrono::{DateTime, Utc};
-    use siege_api::models::{SideOrAll, StatisticResponse};
+    use siege_api::models::{AllOrRanked, SideOrAll, StatisticResponse};
 
     use super::*;
 
@@ -49,7 +49,7 @@ mod test {
         let mut embed = CreateEmbed::default();
         let content = std::fs::read_to_string("../samples/operators.json").unwrap();
         let stats: StatisticResponse = serde_json::from_str(content.as_str()).unwrap();
-        let maps = stats.get_operators(SideOrAll::All);
+        let maps = stats.get_operators(AllOrRanked::All, SideOrAll::All);
 
         embed.format(&maps);
 


### PR DESCRIPTION
Adds option to see data from either `ranked` or `all` with the `/all_*` commands.

## Changelog

- feat: `/all*` commands now include a game mode. Currently only `ranked` and `all` is supported
- chore: Updated changelog and bumped version
- refactor: Formatting and game_mode in title
