### PR TITLE
Fix: Support for reworked map `CONSULATE V2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1]
+
+### Added
+
+- Support for reworked map `CONSULATE V2`.
+
 ## [0.7.0]
 
 ### Added

--- a/siege-api/Cargo.toml
+++ b/siege-api/Cargo.toml
@@ -25,3 +25,4 @@ uuid = { version = "1.3.0", features = ["serde"] }
 async_once = "0.2.6"
 mockall = "0.11.4"
 serde_json = "1.0.95"
+tracing-test = "0.2.4"

--- a/siege-api/Cargo.toml
+++ b/siege-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-api"
-version = "0.6.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]

--- a/siege-api/src/client.rs
+++ b/siege-api/src/client.rs
@@ -272,6 +272,7 @@ mod test {
     use async_once::AsyncOnce;
     use chrono::{DateTime, Duration};
     use lazy_static::lazy_static;
+    use tracing_test::traced_test;
 
     use crate::auth::Auth;
 
@@ -321,6 +322,7 @@ mod test {
         println!("{:?}", stats);
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn maps_statistics() {
         let stats = get_client().await.get_maps(mock_player_id()).await.unwrap();

--- a/siege-api/src/maps.rs
+++ b/siege-api/src/maps.rs
@@ -24,6 +24,8 @@ pub enum Map {
     ClubHouse,
     Coastline,
     Consulate,
+    #[serde(rename = "CONSULATE V2")]
+    ConsulateV2,
     #[serde(rename = "FAVELA V2")]
     Favela,
     Fortress,
@@ -61,7 +63,7 @@ impl Map {
             Self::Chalet => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/Km3ZJUM7ZMVbGsi6gad5Y/c48162371342d9f15386c77a3766315b/r6-maps-chalet.jpg",
             Self::ClubHouse => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/Km3ZJUM7ZMVbGsi6gad5Y/c48162371342d9f15386c77a3766315b/r6-maps-chalet.jpg",
             Self::Coastline => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/5GfAQ3pXCJnDqiqaDH3Zic/db1722cd699bb864ee8f7b0db951b0c3/r6-maps-coastline.jpg",
-            Self::Consulate => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/6PR2sBla9E6TNurVUfJ0mc/860cab16eb1d4cd27ea356a1c3fe9591/r6-maps-consulate.jpg",
+            Self::Consulate | Self::ConsulateV2 => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/6PR2sBla9E6TNurVUfJ0mc/860cab16eb1d4cd27ea356a1c3fe9591/r6-maps-consulate.jpg",
             Self::Favela => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/6PR2sBla9E6TNurVUfJ0mc/860cab16eb1d4cd27ea356a1c3fe9591/r6-maps-consulate.jpg",
             Self::Fortress => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/1MrLwvq61aSSvvUj3dDiZg/18e267c79b8015a1af509a2e5694b18b/r6-maps-fortress.jpg",
             Self::HerefordBase => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/1QHhMYSliWgWXFLxZj19hz/44197c1d98498d8a77618076a19ce538/r6-maps-hereford.jpg",

--- a/siege-bot/Cargo.toml
+++ b/siege-bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-bot"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]


### PR DESCRIPTION
Add support for reworked map `CONSULATE V2`. 

Also added [tracing_test](https://docs.rs/tracing-test/latest/tracing_test/) as a dev dependency to make it easier to debug code through tests without having to add new print statements, which are essentially already there.

## Changelog

- fix: Add support for reworked map `CONSULATE V2`
- chore: Updated changelog and bumped version
