### PR TITLE
chore: Disable rolling logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2]
+
+### Changed
+
+- Disable rolling of log, as it is not really required for the amount of requests at the moment.
+
 ## [0.7.1]
 
 ### Added

--- a/siege-api/Cargo.toml
+++ b/siege-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-api"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]

--- a/siege-bot/Cargo.toml
+++ b/siege-bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-bot"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]
@@ -18,13 +18,13 @@ serenity = { version = "0.11.5", default-features = false, features = [
 tokio = { version = "1.26.0", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-appender = "0.2.2"
 uuid = { version = "1.3.0", features = ["v4"] }
 thiserror = "1.0.40"
 async-trait = "0.1.68"
 duplicate = "1.0.0"
 strum = "0.24.1"
 serde_json = "1.0.95"
-tracing-appender = "0.2.2"
 
 [dev-dependencies]
 chrono = "0.4.24"

--- a/siege-bot/src/main.rs
+++ b/siege-bot/src/main.rs
@@ -25,7 +25,7 @@ impl TypeMapKey for SiegeApi {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // Setup tracing
-    let file_appender = tracing_appender::rolling::daily(
+    let file_appender = tracing_appender::rolling::never(
         var("LOGS_DIR").unwrap_or_else(|_| "./logs/".to_string()),
         "siege-bot.log",
     );


### PR DESCRIPTION
Update logging to avoid rolling it. Right now there is not that much data going through the service, so there is no reason to roll it daily. 