### PR TITLE
fix: Operator response failing because of new class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3]
+
+### Changed
+
+- Added `NoClass` operator roll, which the API has started to return.
+
 ## [0.7.2]
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.69.0 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.70.0 AS chef
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 WORKDIR /app
 

--- a/siege-api/Cargo.toml
+++ b/siege-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-api"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]

--- a/siege-api/src/client.rs
+++ b/siege-api/src/client.rs
@@ -131,10 +131,10 @@ impl SiegeClient for Client {
     async fn get_operators(&self, player_id: Uuid) -> Result<StatisticResponse> {
         let url = create_summary_query(player_id, AggregationType::Operators);
         let response = self.get(url).await?;
-        response
-            .json::<StatisticResponse>()
-            .await
-            .map_err(|_| ConnectError::UnexpectedResponse)
+        response.json::<StatisticResponse>().await.map_err(|err| {
+            tracing::error!("Error: {err:?}");
+            ConnectError::UnexpectedResponse
+        })
     }
 
     /// Get maps statistics for a given player.
@@ -312,6 +312,7 @@ mod test {
         )
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn operators_statistics() {
         let stats = get_client()

--- a/siege-api/src/data/operator.rs
+++ b/siege-api/src/data/operator.rs
@@ -974,7 +974,7 @@ pub fn get_operator_details(operator: Operator) -> OperatorDetails {
             side: Side::Defender,
         },
 
-        Operator::Recruit => OperatorDetails {
+        Operator::Recruit | Operator::NoClass => OperatorDetails {
             realname: "Unknown".to_string(),
             birthplace: "Unknown".to_string(),
             age: 0,

--- a/siege-api/src/operator.rs
+++ b/siege-api/src/operator.rs
@@ -77,6 +77,8 @@ pub enum Operator {
     Tachanka,
     Kapkan,
     Recruit,
+    #[serde(rename = "No Class")]
+    NoClass,
 }
 
 impl Operator {

--- a/siege-bot/Cargo.toml
+++ b/siege-bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-bot"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]


### PR DESCRIPTION
The `operators` endpoint started to return a `NoClass` option. Maybe this is just another way of descriping `Recruit`. Updated the enum to handle that.

## Changelog

- fix: Add `No Class` as an operator variant
- chore: Version bump and changelog
- build: Updated rust version for CI build
