### PR TITLE
fix: Add `other` variants to enums to ensure commands does not fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,6 @@ jobs:
           UBISOFT_EMAIL: ${{ secrets.UBISOFT_EMAIL }}
           UBISOFT_PASSWORD: ${{ secrets.UBISOFT_PASSWORD }}
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.4
         with:
           fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0]
+
+### Changed
+
+- Fixed deseralization of unknown enum variants in `Operator`, `Map`, and `Platform`.
+
 ## [0.8.1]
 
 ### Added

--- a/siege-api/Cargo.toml
+++ b/siege-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-api"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]

--- a/siege-api/src/data/operator.rs
+++ b/siege-api/src/data/operator.rs
@@ -987,7 +987,7 @@ pub fn get_operator_details(operator: Operator) -> OperatorDetails {
             side: Side::Defender,
         },
 
-        Operator::Recruit | Operator::NoClass => OperatorDetails {
+        Operator::Recruit | Operator::NoClass | Operator::Unknown => OperatorDetails {
             realname: "Unknown".to_string(),
             birthplace: "Unknown".to_string(),
             age: 0,

--- a/siege-api/src/game_models.rs
+++ b/siege-api/src/game_models.rs
@@ -36,6 +36,8 @@ pub enum Season {
     Y8S1,
     Y8S2,
     Y8S3,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]

--- a/siege-api/src/maps.rs
+++ b/siege-api/src/maps.rs
@@ -49,6 +49,8 @@ pub enum Map {
     Tower,
     Villa,
     Yacht,
+    #[serde(other)]
+    Unknown,
 }
 
 impl Map {
@@ -78,6 +80,7 @@ impl Map {
             Self::Tower => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/6ZMBunxANmzTNr42wwzggb/3a19c506f9e3f910e34da21095686fa9/r6-maps-tower.jpg",
             Self::Villa => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/Io6dxNeHbCbJoF9WLJf9s/ebf89b009affba37df84dcf1934c74e0/r6-maps-villa.jpg",
             Self::Yacht => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/smDP6lSSaB6Daa7bLZxHZ/d6cc60d76e553e91503a474ff0bc148b/r6-maps-yacht.jpg",
+            Self::Unknown => "",
         }
     }
 }

--- a/siege-api/src/maps.rs
+++ b/siege-api/src/maps.rs
@@ -79,8 +79,7 @@ impl Map {
             Self::ThemePark => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/2immPCOZj6tTHMM9zeBg5B/cf09c9c75bc2e70dd38ebf0a12bdb9a2/r6-maps-themepark.jpg",
             Self::Tower => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/6ZMBunxANmzTNr42wwzggb/3a19c506f9e3f910e34da21095686fa9/r6-maps-tower.jpg",
             Self::Villa => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/Io6dxNeHbCbJoF9WLJf9s/ebf89b009affba37df84dcf1934c74e0/r6-maps-villa.jpg",
-            Self::Yacht => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/smDP6lSSaB6Daa7bLZxHZ/d6cc60d76e553e91503a474ff0bc148b/r6-maps-yacht.jpg",
-            Self::Unknown => "",
+            Self::Yacht | Self::Unknown => "https://staticctf.ubisoft.com/J3yJr34U2pZ2Ieem48Dwy9uqj5PNUQTn/smDP6lSSaB6Daa7bLZxHZ/d6cc60d76e553e91503a474ff0bc148b/r6-maps-yacht.jpg",
         }
     }
 }

--- a/siege-api/src/models/meta.rs
+++ b/siege-api/src/models/meta.rs
@@ -54,6 +54,8 @@ pub enum Platform {
     XboxOne,
     #[serde(rename = "iOS")]
     IOS,
+    #[serde(other)]
+    Unkwon,
 }
 
 #[cfg(test)]

--- a/siege-api/src/operator.rs
+++ b/siege-api/src/operator.rs
@@ -80,6 +80,8 @@ pub enum Operator {
     Recruit,
     #[serde(rename = "No Class")]
     NoClass,
+    #[serde(other)]
+    Unknown,
 }
 
 impl Operator {

--- a/siege-bot/Cargo.toml
+++ b/siege-bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siege-bot"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.69"
 authors = ["Oliver Fleckenstein <oliverfl@live.dk>"]


### PR DESCRIPTION
## Changes

- fix: Add `other` variant to `Platform` when deserializing
- fix: Add `other` variant to other enums
